### PR TITLE
Updated ActivityFeed

### DIFF
--- a/src/main/java/codeu/model/store/basic/ActivityStore.java
+++ b/src/main/java/codeu/model/store/basic/ActivityStore.java
@@ -63,6 +63,12 @@ public class ActivityStore {
     persistentStorageAgent.writeThrough(activity);
   }
 
+  /** Delete an existing activity from the current set of activities known to the application. */
+  public void deleteActivity(Activity activity) {
+    activities.remove(activity);
+    persistentStorageAgent.deleteFrom(activity);
+  }
+
   /** Find and return the activities with the given action. */
   public List<Activity> getActivitiesWithAction(Action action) {
     List<Activity> activityList = new ArrayList<>();

--- a/src/main/java/codeu/model/store/basic/MessageStore.java
+++ b/src/main/java/codeu/model/store/basic/MessageStore.java
@@ -79,6 +79,7 @@ public class MessageStore {
   public void deleteMessage(Message message) {
     messages.remove(message);
     persistentStorageAgent.deleteFrom(message);
+    activityStore.deleteActivity(activityStore.getActivityWithId(message.getId()));
   }
 
   /** Add a new message to the current set of messages known to the application. */

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -156,7 +156,7 @@ public class PersistentDataStore {
    * Loads all Activity objects from the Datastore service and returns them in a List.
    *
    * @throws codeu.model.store.persistence.PersistentDataStoreException if an error was detected
-   *         during the load from the Datastore service
+   *     during the load from the Datastore service
    */
   public List<Activity> loadActivities() throws PersistentDataStoreException {
 
@@ -283,6 +283,19 @@ public class PersistentDataStore {
     for (Entity entity : results.asIterable()) {
       String id = (String) entity.getProperty("uuid");
       if (id.equals(message.getId().toString())) {
+        datastore.delete(entity.getKey());
+      }
+    }
+  }
+
+  /** Delete an Activity object from the Datastore service. */
+  public void deleteFrom(Activity activity) {
+    // Retrieve all activities from the datastore.
+    Query query = new Query("chat-activities").addSort("creation_time", SortDirection.ASCENDING);
+    PreparedQuery results = datastore.prepare(query);
+    for (Entity entity : results.asIterable()) {
+      String id = (String) entity.getProperty("uuid");
+      if (id.equals(activity.getId().toString())) {
         datastore.delete(entity.getKey());
       }
     }

--- a/src/main/java/codeu/model/store/persistence/PersistentStorageAgent.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentStorageAgent.java
@@ -140,4 +140,9 @@ public class PersistentStorageAgent {
   public void deleteFrom(Message message) {
     persistentDataStore.deleteFrom(message);
   }
+
+  /** Delete an Activity object from the Datastore service. */
+  public void deleteFrom(Activity activity) {
+    persistentDataStore.deleteFrom(activity);
+  }
 }

--- a/src/test/java/codeu/model/store/basic/ActivityStoreTest.java
+++ b/src/test/java/codeu/model/store/basic/ActivityStoreTest.java
@@ -1,6 +1,7 @@
 package codeu.model.store.basic;
 
 import static codeu.model.data.ModelDataTestHelpers.assertActivityEquals;
+import static org.junit.Assert.assertTrue;
 
 import codeu.model.data.Action;
 import codeu.model.data.Activity;
@@ -59,6 +60,23 @@ public class ActivityStoreTest {
 
     assertActivityEquals(inputActivity, resultActivity);
     Mockito.verify(mockPersistentStorageAgent).writeThrough(inputActivity);
+  }
+
+  @Test
+  public void testDeleteActivity() {
+    final List<Activity> activityList = new ArrayList<>();
+    activityList.add(
+        new TestActivityBuilder()
+            .withId(UUID.fromString("10000000-2222-3333-4444-555555555555"))
+            .build());
+    activityStore.setActivities(activityList);
+
+    Activity activityToDelete =
+        activityStore.getActivityWithId(UUID.fromString("10000000-2222-3333-4444-555555555555"));
+    activityStore.deleteActivity(activityToDelete);
+
+    assertTrue(activityList.isEmpty());
+    Mockito.verify(mockPersistentStorageAgent).deleteFrom(activityToDelete);
   }
 
   @Test

--- a/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
+++ b/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
@@ -219,5 +219,10 @@ public class PersistentDataStoreTest {
 
     Activity resultActivityTwo = resultActivities.get(1);
     assertActivityEquals(inputActivityTwo, resultActivityTwo);
+
+    // confirm that we deleted all the messages
+    persistentDataStore.deleteFrom(inputActivityOne);
+    persistentDataStore.deleteFrom(inputActivityTwo);
+    Assert.assertTrue(persistentDataStore.loadActivities().isEmpty());
   }
 }

--- a/src/test/java/codeu/model/store/persistence/PersistentStorageAgentTest.java
+++ b/src/test/java/codeu/model/store/persistence/PersistentStorageAgentTest.java
@@ -120,4 +120,18 @@ public class PersistentStorageAgentTest {
     persistentStorageAgent.deleteFrom(message);
     Mockito.verify(mockPersistentDataStore).deleteFrom(message);
   }
+
+  @Test
+  public void testDeleteFromActivity() {
+    Activity activity =
+        new Activity(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            Action.REGISTER_USER,
+            true,
+            Instant.now(),
+            "Joined CodeByter's ");
+    persistentStorageAgent.deleteFrom(activity);
+    Mockito.verify(mockPersistentDataStore).deleteFrom(activity);
+  }
 }


### PR DESCRIPTION
- Added remove functionality for activityStore. 
- Integrated this to the activity feed to take into account deleted messages from users. So, whenever a message is deleted, the activity feed needs to also update its database to avoid null pointer errors. 
