### PR TITLE
Adding "isPrivate" feature to conversation

### DIFF
--- a/src/main/java/codeu/controller/ConversationServlet.java
+++ b/src/main/java/codeu/controller/ConversationServlet.java
@@ -114,7 +114,7 @@ public class ConversationServlet extends HttpServlet {
     }
 
     Conversation conversation =
-        new Conversation(UUID.randomUUID(), user.getId(), conversationTitle, Instant.now());
+        new Conversation(UUID.randomUUID(), user.getId(), conversationTitle, Instant.now(), false);
 
     conversationStore.addConversation(conversation);
     response.sendRedirect("/chat/" + conversationTitle);

--- a/src/main/java/codeu/model/data/Activity.java
+++ b/src/main/java/codeu/model/data/Activity.java
@@ -103,7 +103,7 @@ public class Activity implements Comparable<Activity>{
     return thumbnail;
   }
 
-  /** Returns true if the activity is public. */
+  /** Sets the accessibility of activity. */
   public void setIsPublic(Boolean isPublic) {
     this.isPublic = isPublic;
   }

--- a/src/main/java/codeu/model/data/Conversation.java
+++ b/src/main/java/codeu/model/data/Conversation.java
@@ -15,6 +15,8 @@
 package codeu.model.data;
 
 import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -22,10 +24,14 @@ import java.util.UUID;
  * created by a User and contain Messages.
  */
 public class Conversation {
-  public final UUID id;
-  public final UUID owner;
-  public final Instant creation;
-  public final String title;
+  private final UUID id;
+  private final UUID owner;
+  private final Instant creation;
+  private final String title;
+  private final boolean isPrivate;
+  private Set<String> users;
+
+
 
   /**
    * Constructs a new Conversation.
@@ -34,12 +40,16 @@ public class Conversation {
    * @param owner the ID of the User who created this Conversation
    * @param title the title of this Conversation
    * @param creation the creation time of this Conversation
+   * @param isPrivate how accessible is this activity.
    */
-  public Conversation(UUID id, UUID owner, String title, Instant creation) {
+  public Conversation(UUID id, UUID owner, String title, Instant creation, boolean isPrivate) {
     this.id = id;
     this.owner = owner;
     this.creation = creation;
     this.title = title;
+    this.isPrivate = isPrivate;
+    // Only create a list of users if the conversation is private.
+    if(isPrivate) users = new HashSet<>();
   }
 
   /** Returns the ID of this Conversation. */
@@ -55,6 +65,33 @@ public class Conversation {
   /** Returns the title of this Conversation. */
   public String getTitle() {
     return title;
+  }
+
+  /** Returns the String representation of the users that have acess to the conversation. */
+  public String getUsers() {
+    if(!isPrivate) return null;
+    return String.join(",", this.users);
+  }
+
+  /** Returns true if the conversation is private. */
+  public boolean isPrivate() {
+    return isPrivate;
+  }
+
+  /**
+   * Add the ID of the user to the users. Returns true if the String representation of the User
+   * is added; returns false if the String representation of users Does NOT exists.
+   */
+  public Boolean addUser(UUID userID) {
+    if(!isPrivate) return false;
+    return users.add(userID.toString());
+  }
+
+  /**
+   * Add all the users that should have access to the conversation.
+   */
+  public void setUsers(Set<String> users) {
+    this.users = users;
   }
 
   /** Returns the creation time of this Conversation. */

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -108,7 +108,14 @@ public class PersistentDataStore {
         UUID ownerUuid = UUID.fromString((String) entity.getProperty("owner_uuid"));
         String title = (String) entity.getProperty("title");
         Instant creationTime = Instant.parse((String) entity.getProperty("creation_time"));
-        Conversation conversation = new Conversation(uuid, ownerUuid, title, creationTime);
+        Boolean isPrivate = Boolean.valueOf((String) entity.getProperty("isPrivate"));
+        Conversation conversation = new Conversation(uuid, ownerUuid, title, creationTime, isPrivate);
+        if(isPrivate) {
+          Set<String> users =
+                  new HashSet<String>(
+                          Arrays.asList(((String) (entity.getProperty("users"))).split(",")));
+          conversation.setUsers(users);
+        }
         conversations.add(conversation);
       } catch (Exception e) {
         // In a production environment, errors should be very rare.
@@ -257,6 +264,8 @@ public class PersistentDataStore {
     conversationEntity.setProperty("owner_uuid", conversation.getOwnerId().toString());
     conversationEntity.setProperty("title", conversation.getTitle());
     conversationEntity.setProperty("creation_time", conversation.getCreationTime().toString());
+    conversationEntity.setProperty("isPrivate", String.valueOf(conversation.isPrivate()));
+    if(conversation.isPrivate()) conversationEntity.setProperty("users", conversation.getUsers());
     datastore.put(conversationEntity);
   }
 

--- a/src/test/java/codeu/controller/AdminServletTest.java
+++ b/src/test/java/codeu/controller/AdminServletTest.java
@@ -106,11 +106,12 @@ public class AdminServletTest {
       throws IOException, ServletException {
     List<Conversation> fakeConversationList = new ArrayList<>();
     fakeConversationList.add(
-        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "Conversation1", Instant.now()));
+        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "Conversation1", Instant.now(), false));
     fakeConversationList.add(
-        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "Conversation2", Instant.now()));
+        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "Conversation2", Instant.now(), false));
     fakeConversationList.add(
-        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "Conversation3", Instant.now()));
+        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "Conversation3", Instant.now(),
+                false));
     Mockito.when(mockConversationStore.getAllConversations()).thenReturn(fakeConversationList);
 
     adminServlet.doGet(mockRequest, mockResponse);

--- a/src/test/java/codeu/model/data/ActivityTest.java
+++ b/src/test/java/codeu/model/data/ActivityTest.java
@@ -34,7 +34,7 @@ public class ActivityTest {
     UUID owner = UUID.randomUUID();
     Instant creation = Instant.now();
 
-    Conversation c = new Conversation(id, owner, "Title1", creation);
+    Conversation c = new Conversation(id, owner, "Title1", creation, false);
 
     Activity activity = new Activity(c);
     activity.setIsPublic(false);

--- a/src/test/java/codeu/model/data/ConversationTest.java
+++ b/src/test/java/codeu/model/data/ConversationTest.java
@@ -22,17 +22,40 @@ import org.junit.Test;
 public class ConversationTest {
 
   @Test
-  public void testCreate() {
+  public void testCreate1() {
     UUID id = UUID.randomUUID();
     UUID owner = UUID.randomUUID();
     String title = "Test_Title";
     Instant creation = Instant.now();
+    Boolean isPrivate = false;
 
-    Conversation conversation = new Conversation(id, owner, title, creation);
+    Conversation conversation = new Conversation(id, owner, title, creation, isPrivate);
 
     Assert.assertEquals(id, conversation.getId());
     Assert.assertEquals(owner, conversation.getOwnerId());
     Assert.assertEquals(title, conversation.getTitle());
     Assert.assertEquals(creation, conversation.getCreationTime());
+    Assert.assertEquals(isPrivate, conversation.isPrivate());
+    // Testing that users IS null
+    Assert.assertNull(conversation.getUsers());
+  }
+
+  @Test
+  public void testCreate2() {
+    UUID id = UUID.randomUUID();
+    UUID owner = UUID.randomUUID();
+    String title = "Test_Title";
+    Instant creation = Instant.now();
+    Boolean isPrivate = true;
+
+    Conversation conversation = new Conversation(id, owner, title, creation, isPrivate);
+
+    Assert.assertEquals(id, conversation.getId());
+    Assert.assertEquals(owner, conversation.getOwnerId());
+    Assert.assertEquals(title, conversation.getTitle());
+    Assert.assertEquals(creation, conversation.getCreationTime());
+    Assert.assertEquals(isPrivate, conversation.isPrivate());
+    // Testing the creation of the set users
+    Assert.assertTrue(conversation.getUsers().isEmpty());
   }
 }

--- a/src/test/java/codeu/model/data/ModelDataTestHelpers.java
+++ b/src/test/java/codeu/model/data/ModelDataTestHelpers.java
@@ -118,6 +118,7 @@ public class ModelDataTestHelpers {
     private UUID ownerId;
     private String title;
     private Instant creationTime;
+    private boolean isPrivate;
 
     public TestConversationBuilder() {
       this.id = UUID.randomUUID();
@@ -146,8 +147,13 @@ public class ModelDataTestHelpers {
       return this;
     }
 
+    public TestConversationBuilder withIsPrivate(boolean isPrivate) {
+      this.isPrivate = isPrivate;
+      return this;
+    }
+
     public Conversation build() {
-      return new Conversation(id, ownerId, title, creationTime);
+      return new Conversation(id, ownerId, title, creationTime, isPrivate);
     }
   }
 

--- a/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
+++ b/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
@@ -80,13 +80,13 @@ public class PersistentDataStoreTest {
     UUID ownerOne = UUID.fromString("10000001-2222-3333-4444-555555555555");
     String titleOne = "Test_Title";
     Instant creationOne = Instant.ofEpochMilli(1000);
-    Conversation inputConversationOne = new Conversation(idOne, ownerOne, titleOne, creationOne);
+    Conversation inputConversationOne = new Conversation(idOne, ownerOne, titleOne, creationOne, false);
 
     UUID idTwo = UUID.fromString("10000002-2222-3333-4444-555555555555");
     UUID ownerTwo = UUID.fromString("10000003-2222-3333-4444-555555555555");
     String titleTwo = "Test_Title_Two";
     Instant creationTwo = Instant.ofEpochMilli(2000);
-    Conversation inputConversationTwo = new Conversation(idTwo, ownerTwo, titleTwo, creationTwo);
+    Conversation inputConversationTwo = new Conversation(idTwo, ownerTwo, titleTwo, creationTwo, false);
 
     // save
     persistentDataStore.writeThrough(inputConversationOne);

--- a/src/test/java/codeu/model/store/persistence/PersistentStorageAgentTest.java
+++ b/src/test/java/codeu/model/store/persistence/PersistentStorageAgentTest.java
@@ -70,7 +70,7 @@ public class PersistentStorageAgentTest {
   @Test
   public void testWriteThroughConversation() {
     Conversation conversation =
-        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now());
+        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now(), false);
     persistentStorageAgent.writeThrough(conversation);
     Mockito.verify(mockPersistentDataStore).writeThrough(conversation);
   }


### PR DESCRIPTION
- Updated the constructor of conversation by adding "isPrivate".
- Added a field into conversation named users. This SET is initialized whenever a conversation is private. Then, it helps us keep track of who has access to a particular conversation. 
-  Added with tests. 
-> In progress 
