### PR TITLE
Removing HashtagConv section

### DIFF
--- a/src/main/webapp/WEB-INF/view/conversations.jsp
+++ b/src/main/webapp/WEB-INF/view/conversations.jsp
@@ -74,22 +74,6 @@ List<Conversation> conversations = (List<Conversation>) request.getAttribute("co
     <% } %>
     <hr/>
 
-    <h1>Hashtag Conversations</h1>
-    <% if (conversations == null || conversations.isEmpty()) { %>
-      <p>Create a Hashtag conversation to get started.</p>
-    <% } else { %>
-      <ul class="mdl-list">
-        <% for (Conversation conversation : conversations) { %>
-        <% if (conversation.getTitle().toLowerCase().contains("hashtag")){ %>
-        	<li><a href="/chat/<%= conversation.getTitle() %>">
-              <%= conversation.getTitle() %></a></li>
-        <% } %>
-
-        <% } %>
-      </ul>
-    <% } %>
-
-
   </div>
 </body>
 </html>


### PR DESCRIPTION
Had to remove the "hashtag conversation" section from /conversations page because could not find suitable regular expression that would not allow special characters but the '#' 
[as of now, # is not allowed in conversation title]