### PR TITLE
Fixed admin bug

### DIFF
--- a/src/main/java/codeu/controller/ConversationServlet.java
+++ b/src/main/java/codeu/controller/ConversationServlet.java
@@ -123,7 +123,10 @@ public class ConversationServlet extends HttpServlet {
       // Add the first user, which is the creator.
       conversation.addUser(user.getId());
       // For admin purpose, add the admin too.
-      conversation.addUser(userStore.getUser("admin01").getId());
+      if (user.getId() != userStore.getUser("admin01").getId()) {
+        // For admin purpose, add the admin too.
+        conversation.addUser(userStore.getUser("admin01").getId());
+      }
     }
     conversationStore.addConversation(conversation);
     response.sendRedirect("/chat/" + conversationTitle);

--- a/src/main/java/codeu/controller/ConversationServlet.java
+++ b/src/main/java/codeu/controller/ConversationServlet.java
@@ -124,7 +124,6 @@ public class ConversationServlet extends HttpServlet {
       conversation.addUser(user.getId());
       // For admin purpose, add the admin too.
       if (user.getId() != userStore.getUser("admin01").getId()) {
-        // For admin purpose, add the admin too.
         conversation.addUser(userStore.getUser("admin01").getId());
       }
     }


### PR DESCRIPTION
Because we were trying to add the admin to all private conversations so we can view it, it was causing an error when the Admin him/herself tried to create their own private conversation.

In the PR I just checked if the logged in user was the Admin, and if so, don't re-add the admin.